### PR TITLE
Replaced x-code-samples with x-codeSamples

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ function enrichSchema(schema){
 			
 		for(var method in schema.paths[path]){
 			var generatedCode = OpenAPISnippet.getEndpointSnippets(schema, path, method, targets);
-			schema.paths[path][method]["x-code-samples"] = [];
+			schema.paths[path][method]["x-codeSamples"] = [];
 			for(var snippetIdx in generatedCode.snippets){
 				var snippet = generatedCode.snippets[snippetIdx];
-				schema.paths[path][method]["x-code-samples"][snippetIdx] = { "lang": snippet.title, "source": snippet.content };
+				schema.paths[path][method]["x-codeSamples"][snippetIdx] = { "lang": snippet.title, "source": snippet.content };
 			}
 			
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snippet-enricher-cli",
   "version": "0.0.6",
-  "description": "Enrich OpenAPI 3.0 JSON with code snippets (``x-code-samples``)",
+  "description": "Enrich OpenAPI 3.0 JSON with code snippets (``x-codeSamples``)",
   "repository": {
     "type": "git",
     "url": "https://github.com/cdwv/oas3-api-snippet-enricher"


### PR DESCRIPTION
The x-code-samples is deprecated in favour of x-codeSamples. This PR uses the new extension.