### PR TITLE
Skip custom methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,17 @@ function enrichSchema(schema){
 			
 		for(var method in schema.paths[path]){
 			if (method.indexOf('x-') === 0) continue;
-			var generatedCode = OpenAPISnippet.getEndpointSnippets(schema, path, method, targets);
-			schema.paths[path][method]["x-codeSamples"] = [];
-			for(var snippetIdx in generatedCode.snippets){
-				var snippet = generatedCode.snippets[snippetIdx];
-				schema.paths[path][method]["x-codeSamples"][snippetIdx] = { "lang": snippet.title, "source": snippet.content };
-			}
-			
+			try {
+        var generatedCode = OpenAPISnippet.getEndpointSnippets(schema, path, method, targets);
+        schema.paths[path][method]["x-codeSamples"] = [];
+        for(var snippetIdx in generatedCode.snippets){
+          var snippet = generatedCode.snippets[snippetIdx];
+          schema.paths[path][method]["x-codeSamples"][snippetIdx] = { "lang": snippet.title, "source": snippet.content };
+        }
+      }
+      catch (err) {
+        console.error(`Error while processing "${method}" "${path}"\n`, err);
+      }
 		}
 	}
 	return schema;

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function enrichSchema(schema){
 	for(var path in schema.paths){
 			
 		for(var method in schema.paths[path]){
+			if (method.indexOf('x-') === 0) continue;
 			var generatedCode = OpenAPISnippet.getEndpointSnippets(schema, path, method, targets);
 			schema.paths[path][method]["x-codeSamples"] = [];
 			for(var snippetIdx in generatedCode.snippets){


### PR DESCRIPTION
Fix #12 

Also add error handling so partial transformation can still happen as openapi-snippet doesn't support some minor things (like oneOf/allOf in parameter schemas)