### PR TITLE
Fix: Typo - duplicate `>` char.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples
 
 Use targets options to specific languages:
 ```
-./node_modules/.bin/snippet-enricher-cli --targets="node_request,shell_curl" --input=openapi.json >  > openapi-with-examples.json
+./node_modules/.bin/snippet-enricher-cli --targets="node_request,shell_curl" --input=openapi.json > openapi-with-examples.json
 ```
 
 Use [ReDoc](https://github.com/Redocly/redoc/) to build beautiful API doc:


### PR DESCRIPTION
Running through the readme -

`./node_modules/.bin/snippet-enricher-cli --targets="node_request,shell_curl" --input=openapi.json >  > openapi-with-examples.json`

returns an error. Removing the duplicate right arrow char enables the command to run.