### PR TITLE
Generate code sample only on operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function enrichSchema(schema){
 	for(var path in schema.paths){
 			
 		for(var method in schema.paths[path]){
+			if ( !/get|put|post|delete|patch|options|head|trace/.test(method)) { continue; }
 			var generatedCode = OpenAPISnippet.getEndpointSnippets(schema, path, method, targets);
 			schema.paths[path][method]["x-codeSamples"] = [];
 			for(var snippetIdx in generatedCode.snippets){


### PR DESCRIPTION
Code samples should only be added onto operations.
This fixes issues #13 and #17