### PR TITLE
Update deps to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "author": "Andrzej WP",
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "^3.13.1",
-    "openapi-snippet": "^0.9.0",
-    "yargs": "^15.3.1"
+    "js-yaml": "^4.1.0",
+    "openapi-snippet": "^0.14.0",
+    "yargs": "^17.7.2"
   }
 }


### PR DESCRIPTION
The previous version of openapi-snippet did not support following refs to detect the content type for each endpoint.  This resulted in generated snippets missing the content type argument if they used a ref.